### PR TITLE
feat: add hourly availability graph to station detail panel

### DIFF
--- a/src/HslBikeApp/Components/StationDetailPanel.razor
+++ b/src/HslBikeApp/Components/StationDetailPanel.razor
@@ -1,3 +1,5 @@
+@using System.Globalization
+
 <div class="detail-panel">
     <button class="back-btn" @onclick="OnBack">&#8592; Back to map</button>
 
@@ -31,6 +33,38 @@
             <svg class="sparkline" width="200" height="40" viewBox="0 0 200 40" aria-label="Bike availability trend">
                 <polyline points="@GetSparklinePoints()" />
             </svg>
+        }
+    </div>
+
+    <div class="detail-card">
+        <h4>Typical Availability</h4>
+
+        @if (IsLoadingAvailability)
+        {
+            <div class="loading-spinner" style="width:24px;height:24px;border-width:3px;margin:12px auto;"></div>
+        }
+        else if (AvailabilityProfile.Count == 0)
+        {
+            <div class="availability-empty">No hourly availability available yet.</div>
+        }
+        else
+        {
+            <div class="availability-legend">Current hour highlighted</div>
+            <div class="availability-chart-wrapper">
+                <div class="availability-chart" role="img" aria-label="Typical bike availability by hour">
+                    @foreach (var bucket in AvailabilityProfile.OrderBy(item => item.Hour))
+                    {
+                        <div class="availability-column @(IsCurrentHour(bucket.Hour) ? "current" : string.Empty)"
+                             title="@GetAvailabilityLabel(bucket)"
+                             aria-label="@GetAvailabilityLabel(bucket)">
+                            <div class="availability-bar-track">
+                                <div class="availability-bar" style="@GetBarStyle(bucket)"></div>
+                            </div>
+                            <div class="availability-hour">@bucket.Hour.ToString("00", CultureInfo.InvariantCulture)</div>
+                        </div>
+                    }
+                </div>
+            </div>
         }
     </div>
 
@@ -84,9 +118,13 @@
     [Parameter] public required BikeStation Station { get; set; }
     [Parameter] public List<StationHistory> History { get; set; } = [];
     [Parameter] public bool IsLoadingHistory { get; set; }
+    [Parameter] public List<HourlyAvailability> AvailabilityProfile { get; set; } = [];
+    [Parameter] public bool IsLoadingAvailability { get; set; }
     [Parameter] public AvailabilityTrend Trend { get; set; }
     [Parameter] public List<int> Sparkline { get; set; } = [];
     [Parameter] public EventCallback OnBack { get; set; }
+
+    private static readonly CultureInfo InvariantCulture = CultureInfo.InvariantCulture;
 
     private string GetTrendClass() => Trend switch
     {
@@ -119,4 +157,19 @@
             $"{(i * step).ToString("0.1", System.Globalization.CultureInfo.InvariantCulture)},{(height - (double)v / max * height).ToString("0.1", System.Globalization.CultureInfo.InvariantCulture)}"
         ));
     }
+
+    private string GetBarStyle(HourlyAvailability bucket)
+    {
+        var max = AvailabilityProfile.Count == 0 ? 0 : AvailabilityProfile.Max(item => item.AverageBikesAvailable);
+        var heightPercentage = max <= 0
+            ? 6.0
+            : Math.Max(6.0, bucket.AverageBikesAvailable / max * 100.0);
+
+        return $"height: {heightPercentage.ToString("0.##", InvariantCulture)}%;";
+    }
+
+    private static bool IsCurrentHour(int hour) => DateTime.Now.Hour == hour;
+
+    private static string GetAvailabilityLabel(HourlyAvailability bucket) =>
+        $"{bucket.Hour.ToString("00", InvariantCulture)}:00 average {bucket.AverageBikesAvailable.ToString("0.0", InvariantCulture)} bikes";
 }

--- a/src/HslBikeApp/Models/HourlyAvailability.cs
+++ b/src/HslBikeApp/Models/HourlyAvailability.cs
@@ -1,0 +1,7 @@
+namespace HslBikeApp.Models;
+
+public record HourlyAvailability
+{
+    public int Hour { get; init; }
+    public double AverageBikesAvailable { get; init; }
+}

--- a/src/HslBikeApp/Pages/Home.razor
+++ b/src/HslBikeApp/Pages/Home.razor
@@ -92,6 +92,8 @@
     <StationDetailPanel Station="State.SelectedStation"
                         History="State.History"
                         IsLoadingHistory="State.IsLoadingHistory"
+                        AvailabilityProfile="State.AvailabilityProfile"
+                        IsLoadingAvailability="State.IsLoadingAvailability"
                         Trend="@State.GetTrend(State.SelectedStation.Id)"
                         Sparkline="@State.GetSparkline(State.SelectedStation.Id)"
                         OnBack="OnBackFromDetail" />
@@ -111,12 +113,14 @@
     private bool _showDetail;
     private bool _showSearch;
     private bool _showInfo;
+    private Action? _stateChangedHandler;
 
     private bool HasActiveSearch => !string.IsNullOrWhiteSpace(State.SearchQuery);
 
     protected override async Task OnInitializedAsync()
     {
-        State.OnStateChanged += StateHasChanged;
+        _stateChangedHandler = () => _ = InvokeAsync(StateHasChanged);
+        State.OnStateChanged += _stateChangedHandler;
         await State.InitAsync();
     }
 
@@ -160,5 +164,9 @@
     private static string FormatUtc(DateTime value) =>
         value.ToString("yyyy-MM-dd HH:mm 'UTC'", CultureInfo.InvariantCulture);
 
-    public void Dispose() => State.OnStateChanged -= StateHasChanged;
+    public void Dispose()
+    {
+        if (_stateChangedHandler is not null)
+            State.OnStateChanged -= _stateChangedHandler;
+    }
 }

--- a/src/HslBikeApp/Program.cs
+++ b/src/HslBikeApp/Program.cs
@@ -16,6 +16,7 @@ if (string.IsNullOrWhiteSpace(aggregatorBaseUrl))
 var plainHttp = new HttpClient();
 
 builder.Services.AddSingleton(new StationService(plainHttp, aggregatorBaseUrl));
+builder.Services.AddSingleton(new AvailabilityService(plainHttp, aggregatorBaseUrl));
 builder.Services.AddSingleton(new HistoryService(plainHttp, aggregatorBaseUrl));
 builder.Services.AddSingleton(new CycleLaneService(plainHttp));
 builder.Services.AddSingleton(new SnapshotService(plainHttp, aggregatorBaseUrl));

--- a/src/HslBikeApp/Services/AvailabilityService.cs
+++ b/src/HslBikeApp/Services/AvailabilityService.cs
@@ -1,0 +1,47 @@
+using System.Net;
+using System.Net.Http.Json;
+using HslBikeApp.Models;
+
+namespace HslBikeApp.Services;
+
+public class AvailabilityService
+{
+    private readonly HttpClient _http;
+    private readonly string _baseUrl;
+
+    public AvailabilityService(HttpClient http, string baseUrl)
+    {
+        ArgumentNullException.ThrowIfNull(http);
+
+        if (string.IsNullOrWhiteSpace(baseUrl))
+            throw new ArgumentException("Aggregator base URL must be configured.", nameof(baseUrl));
+
+        _http = http;
+        _baseUrl = baseUrl.TrimEnd('/');
+    }
+
+    public async Task<List<HourlyAvailability>> FetchAvailabilityAsync(string stationId)
+    {
+        if (string.IsNullOrWhiteSpace(stationId))
+            throw new ArgumentException("Station ID must be provided.", nameof(stationId));
+
+        var url = $"{_baseUrl}/api/stations/{Uri.EscapeDataString(stationId)}/availability";
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await _http.GetAsync(url);
+        }
+        catch (HttpRequestException)
+        {
+            return [];
+        }
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            return [];
+
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<List<HourlyAvailability>>() ?? [];
+    }
+}

--- a/src/HslBikeApp/State/AppState.cs
+++ b/src/HslBikeApp/State/AppState.cs
@@ -6,6 +6,7 @@ namespace HslBikeApp.State;
 public class AppState : IDisposable
 {
     private readonly StationService _stationService;
+    private readonly AvailabilityService _availabilityService;
     private readonly HistoryService _historyService;
     private readonly CycleLaneService _cycleLaneService;
     private readonly SnapshotService _snapshotService;
@@ -40,6 +41,8 @@ public class AppState : IDisposable
     public BikeStation? SelectedStation { get; private set; }
     public List<StationHistory> History { get; private set; } = [];
     public bool IsLoadingHistory { get; private set; }
+    public List<HourlyAvailability> AvailabilityProfile { get; private set; } = [];
+    public bool IsLoadingAvailability { get; private set; }
 
     // --------------- cycle lanes ---------------
     public List<CycleLane> CycleLanes { get; private set; } = [];
@@ -57,11 +60,13 @@ public class AppState : IDisposable
 
     public AppState(
         StationService stationService,
+        AvailabilityService availabilityService,
         HistoryService historyService,
         CycleLaneService cycleLaneService,
         SnapshotService snapshotService)
     {
         _stationService = stationService;
+        _availabilityService = availabilityService;
         _historyService = historyService;
         _cycleLaneService = cycleLaneService;
         _snapshotService = snapshotService;
@@ -141,23 +146,58 @@ public class AppState : IDisposable
 
     public async Task SelectStationAsync(BikeStation station)
     {
+        ArgumentNullException.ThrowIfNull(station);
+
         SelectedStation = station;
         History = [];
+        AvailabilityProfile = [];
         IsLoadingHistory = true;
+        IsLoadingAvailability = true;
         NotifyStateChanged();
+
+        var historyTask = TryFetchHistoryAsync(station.Id);
+        var availabilityTask = TryFetchAvailabilityAsync(station.Id);
 
         try
         {
-            History = await _historyService.FetchHistoryAsync(station.Id);
-        }
-        catch
-        {
-            History = [];
+            var history = await historyTask;
+            var availability = await availabilityTask;
+
+            if (SelectedStation?.Id == station.Id)
+            {
+                History = history;
+                AvailabilityProfile = availability;
+            }
         }
         finally
         {
             IsLoadingHistory = false;
+            IsLoadingAvailability = false;
             NotifyStateChanged();
+        }
+    }
+
+    private async Task<List<StationHistory>> TryFetchHistoryAsync(string stationId)
+    {
+        try
+        {
+            return await _historyService.FetchHistoryAsync(stationId);
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private async Task<List<HourlyAvailability>> TryFetchAvailabilityAsync(string stationId)
+    {
+        try
+        {
+            return await _availabilityService.FetchAvailabilityAsync(stationId);
+        }
+        catch
+        {
+            return [];
         }
     }
 
@@ -165,6 +205,9 @@ public class AppState : IDisposable
     {
         SelectedStation = null;
         History = [];
+        AvailabilityProfile = [];
+        IsLoadingHistory = false;
+        IsLoadingAvailability = false;
         NotifyStateChanged();
     }
 

--- a/src/HslBikeApp/wwwroot/css/app.css
+++ b/src/HslBikeApp/wwwroot/css/app.css
@@ -396,6 +396,73 @@ html, body {
     stroke-width: 2;
 }
 
+/* ===== Availability chart ===== */
+.availability-legend,
+.availability-empty {
+    color: var(--text-secondary);
+    font-size: 12px;
+}
+
+.availability-legend {
+    margin-bottom: 10px;
+}
+
+.availability-chart-wrapper {
+    overflow-x: auto;
+    padding-bottom: 4px;
+}
+
+.availability-chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 4px;
+    min-width: 320px;
+    height: 160px;
+}
+
+.availability-column {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+}
+
+.availability-bar-track {
+    width: 100%;
+    height: 132px;
+    padding: 3px;
+    display: flex;
+    align-items: flex-end;
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--surface) 78%, var(--border));
+}
+
+.availability-bar {
+    width: 100%;
+    border-radius: 7px 7px 4px 4px;
+    background: color-mix(in srgb, var(--primary) 60%, var(--primary-light));
+}
+
+.availability-hour {
+    font-size: 10px;
+    color: var(--text-secondary);
+}
+
+.availability-column.current .availability-bar-track {
+    background: color-mix(in srgb, var(--primary-light) 45%, var(--surface));
+}
+
+.availability-column.current .availability-bar {
+    background: var(--primary);
+}
+
+.availability-column.current .availability-hour {
+    color: var(--primary-dark);
+    font-weight: 700;
+}
+
 /* ===== Destination list ===== */
 .destination-list {
     list-style: none;

--- a/tests/HslBikeApp.Tests/Services/AvailabilityServiceTests.cs
+++ b/tests/HslBikeApp.Tests/Services/AvailabilityServiceTests.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using System.Text;
+using HslBikeApp.Services;
+
+namespace HslBikeApp.Tests.Services;
+
+public class AvailabilityServiceTests
+{
+    [Fact]
+    public async Task FetchAvailabilityAsync_WhenResponseIsSuccessful_ReturnsTwentyFourHourlyBuckets()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        var responseJson =
+            """
+            [
+            { "hour": 0, "averageBikesAvailable": 0.5 },
+            { "hour": 1, "averageBikesAvailable": 1.5 },
+            { "hour": 2, "averageBikesAvailable": 2.5 },
+            { "hour": 3, "averageBikesAvailable": 3.5 },
+            { "hour": 4, "averageBikesAvailable": 4.5 },
+            { "hour": 5, "averageBikesAvailable": 5.5 },
+            { "hour": 6, "averageBikesAvailable": 6.5 },
+            { "hour": 7, "averageBikesAvailable": 7.5 },
+            { "hour": 8, "averageBikesAvailable": 8.5 },
+            { "hour": 9, "averageBikesAvailable": 9.5 },
+            { "hour": 10, "averageBikesAvailable": 10.5 },
+            { "hour": 11, "averageBikesAvailable": 11.5 },
+            { "hour": 12, "averageBikesAvailable": 12.5 },
+            { "hour": 13, "averageBikesAvailable": 13.5 },
+            { "hour": 14, "averageBikesAvailable": 14.5 },
+            { "hour": 15, "averageBikesAvailable": 15.5 },
+            { "hour": 16, "averageBikesAvailable": 16.5 },
+            { "hour": 17, "averageBikesAvailable": 17.5 },
+            { "hour": 18, "averageBikesAvailable": 18.5 },
+            { "hour": 19, "averageBikesAvailable": 19.5 },
+            { "hour": 20, "averageBikesAvailable": 20.5 },
+            { "hour": 21, "averageBikesAvailable": 21.5 },
+            { "hour": 22, "averageBikesAvailable": 22.5 },
+            { "hour": 23, "averageBikesAvailable": 23.5 }
+            ]
+            """;
+
+        var httpClient = new HttpClient(new StubHttpMessageHandler((request, _) =>
+        {
+            capturedRequest = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+            });
+        }));
+        var service = new AvailabilityService(httpClient, "https://aggregator.example/");
+
+        var availability = await service.FetchAvailabilityAsync("001");
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal("https://aggregator.example/api/stations/001/availability", capturedRequest.RequestUri?.ToString());
+        Assert.Equal(24, availability.Count);
+        Assert.Equal(0, availability[0].Hour);
+        Assert.Equal(23.5, availability[23].AverageBikesAvailable);
+    }
+
+    [Fact]
+    public async Task FetchAvailabilityAsync_WhenResponseIsEmpty_ReturnsEmptyList()
+    {
+        var httpClient = new HttpClient(new StubHttpMessageHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("[]", Encoding.UTF8, "application/json")
+        })));
+        var service = new AvailabilityService(httpClient, "https://aggregator.example");
+
+        var availability = await service.FetchAvailabilityAsync("001");
+
+        Assert.Empty(availability);
+    }
+
+    [Fact]
+    public async Task FetchAvailabilityAsync_WhenResponseIsNotFound_ReturnsEmptyList()
+    {
+        var httpClient = new HttpClient(new StubHttpMessageHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound))));
+        var service = new AvailabilityService(httpClient, "https://aggregator.example");
+
+        var availability = await service.FetchAvailabilityAsync("001");
+
+        Assert.Empty(availability);
+    }
+}

--- a/tests/HslBikeApp.Tests/Services/ServiceConfigurationTests.cs
+++ b/tests/HslBikeApp.Tests/Services/ServiceConfigurationTests.cs
@@ -48,13 +48,15 @@ public class ServiceConfigurationTests
 
         var stationService = new StationService(httpClient, baseUrl);
         var snapshotService = new SnapshotService(httpClient, baseUrl);
+        var availabilityService = new AvailabilityService(httpClient, baseUrl);
         var historyService = new HistoryService(httpClient, baseUrl);
 
         await stationService.FetchStationsAsync();
         await snapshotService.FetchSnapshotsAsync();
+        await availabilityService.FetchAvailabilityAsync("001");
         await historyService.FetchHistoryAsync("001");
 
-        Assert.Equal(3, capturedUris.Count);
+        Assert.Equal(4, capturedUris.Count);
         Assert.All(capturedUris, uri =>
         {
             Assert.Equal("aggregator.example", uri.Host);

--- a/tests/HslBikeApp.Tests/State/AppStateTests.cs
+++ b/tests/HslBikeApp.Tests/State/AppStateTests.cs
@@ -10,7 +10,8 @@ public class AppStateTests
 {
     private static AppState CreateAppState(
         List<BikeStation>? stations = null,
-        List<StationSnapshot>? snapshots = null)
+        List<StationSnapshot>? snapshots = null,
+        List<HourlyAvailability>? availability = null)
     {
         var stationHandler = new MockHttpHandler();
         if (stations is not null)
@@ -24,6 +25,15 @@ public class AppStateTests
 
         var stationService = new StationService(new HttpClient(stationHandler) { BaseAddress = new Uri("https://test.local/") }, "https://test.local");
         var historyService = new HistoryService(new HttpClient(new MockHttpHandler()), "https://test.local");
+        var availabilityHandler = new MockHttpHandler();
+        if (availability is not null)
+        {
+            availabilityHandler.SetResponse("/availability", JsonSerializer.Serialize(availability, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            }));
+        }
+        var availabilityService = new AvailabilityService(new HttpClient(availabilityHandler) { BaseAddress = new Uri("https://test.local/") }, "https://test.local");
         var cycleLaneService = new CycleLaneService(new HttpClient(new MockHttpHandler()));
 
         var snapshotHandler = new MockHttpHandler();
@@ -36,7 +46,7 @@ public class AppStateTests
         }
         var snapshotService = new SnapshotService(new HttpClient(snapshotHandler) { BaseAddress = new Uri("https://test.local/") }, "https://test.local");
 
-        return new AppState(stationService, historyService, cycleLaneService, snapshotService);
+        return new AppState(stationService, availabilityService, historyService, cycleLaneService, snapshotService);
     }
 
     [Fact]
@@ -141,9 +151,34 @@ public class AppStateTests
     public void ClearSelection_ResetsState()
     {
         var state = CreateAppState();
+        typeof(AppState).GetProperty("AvailabilityProfile")!.SetValue(state, new List<HourlyAvailability>
+        {
+            new() { Hour = 8, AverageBikesAvailable = 5.2 }
+        });
         state.ClearSelection();
         Assert.Null(state.SelectedStation);
         Assert.Empty(state.History);
+        Assert.Empty(state.AvailabilityProfile);
+    }
+
+    [Fact]
+    public async Task SelectStationAsync_PopulatesAvailabilityProfile()
+    {
+        var availability = Enumerable.Range(0, 24)
+            .Select(hour => new HourlyAvailability
+            {
+                Hour = hour,
+                AverageBikesAvailable = hour / 2.0
+            })
+            .ToList();
+
+        var state = CreateAppState(availability: availability);
+        var station = new BikeStation { Id = "001", Name = "Kamppi", Address = "Address" };
+
+        await state.SelectStationAsync(station);
+
+        Assert.Equal(24, state.AvailabilityProfile.Count);
+        Assert.False(state.IsLoadingAvailability);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Add an hourly availability graph to the station detail panel, showing typical bike availability throughout the day (24 hourly buckets).

## Changes

- **Model**: `HourlyAvailability` record in `Models/`
- **Service**: `AvailabilityService` calling `GET /api/stations/{id}/availability`
- **DI**: Registered in `Program.cs` with `AggregatorBaseUrl`
- **State**: `AppState` loads availability profile alongside history (in parallel)
- **UI**: CSS bar chart in `StationDetailPanel` with current-hour highlight
- **Fallback**: Graceful message when no data is available
- **Tests**: `AvailabilityServiceTests` (deserialisation, empty, 404), updated `AppStateTests` and `ServiceConfigurationTests`

## Acceptance Criteria

- [x] Clicking a station shows a 24-hour availability profile
- [x] Current hour is visually highlighted
- [x] Graceful fallback when no data is available yet
- [x] New unit tests pass (47/47)

Closes #4