### PR TITLE
Add X-App-Source header handler and update API base URL to APIM gateway

### DIFF
--- a/src/HslBikeApp/Http/AppSourceHeaderHandler.cs
+++ b/src/HslBikeApp/Http/AppSourceHeaderHandler.cs
@@ -1,0 +1,29 @@
+namespace HslBikeApp.Http;
+
+/// <summary>
+/// HTTP message handler that adds the X-App-Source header to all outgoing requests.
+/// This header is used by Azure API Management for casual-abuse filtering.
+/// </summary>
+public sealed class AppSourceHeaderHandler : DelegatingHandler
+{
+    private const string HeaderName = "X-App-Source";
+    private const string HeaderValue = "HslBikeApp";
+
+    public AppSourceHeaderHandler()
+    {
+        InnerHandler = new HttpClientHandler();
+    }
+
+    public AppSourceHeaderHandler(HttpMessageHandler innerHandler)
+    {
+        InnerHandler = innerHandler;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        request.Headers.Add(HeaderName, HeaderValue);
+        return base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/HslBikeApp/Program.cs
+++ b/src/HslBikeApp/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using HslBikeApp;
+using HslBikeApp.Http;
 using HslBikeApp.Services;
 using HslBikeApp.State;
 
@@ -13,13 +14,14 @@ var aggregatorBaseUrl = config["AggregatorBaseUrl"];
 if (string.IsNullOrWhiteSpace(aggregatorBaseUrl))
     aggregatorBaseUrl = "https://kuoste.github.io/hsl-bike-data-aggregator";
 
-var plainHttp = new HttpClient();
+var httpClientWithHeaders = new HttpClient(new AppSourceHeaderHandler());
+var plainHttpClient = new HttpClient();
 
-builder.Services.AddSingleton(new StationService(plainHttp, aggregatorBaseUrl));
-builder.Services.AddSingleton(new AvailabilityService(plainHttp, aggregatorBaseUrl));
-builder.Services.AddSingleton(new HistoryService(plainHttp, aggregatorBaseUrl));
-builder.Services.AddSingleton(new CycleLaneService(plainHttp));
-builder.Services.AddSingleton(new SnapshotService(plainHttp, aggregatorBaseUrl));
+builder.Services.AddSingleton(new StationService(httpClientWithHeaders, aggregatorBaseUrl));
+builder.Services.AddSingleton(new AvailabilityService(httpClientWithHeaders, aggregatorBaseUrl));
+builder.Services.AddSingleton(new HistoryService(httpClientWithHeaders, aggregatorBaseUrl));
+builder.Services.AddSingleton(new CycleLaneService(plainHttpClient));
+builder.Services.AddSingleton(new SnapshotService(httpClientWithHeaders, aggregatorBaseUrl));
 builder.Services.AddSingleton<AppState>();
 
 await builder.Build().RunAsync();

--- a/src/HslBikeApp/wwwroot/appsettings.json
+++ b/src/HslBikeApp/wwwroot/appsettings.json
@@ -1,3 +1,3 @@
 {
-  "AggregatorBaseUrl": "https://func-hsl-bike-data-aggregator-dev.azurewebsites.net"
+  "AggregatorBaseUrl": "https://apim-hsl-bike-data-aggregator-dev.azure-api.net"
 }

--- a/tests/HslBikeApp.Tests/Http/AppSourceHeaderHandlerTests.cs
+++ b/tests/HslBikeApp.Tests/Http/AppSourceHeaderHandlerTests.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using HslBikeApp.Http;
+using HslBikeApp.Tests;
+
+namespace HslBikeApp.Tests.Http;
+
+public class AppSourceHeaderHandlerTests
+{
+    [Fact]
+    public async Task SendAsync_AddsXAppSourceHeader()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        var innerHandler = new StubHttpMessageHandler((req, ct) =>
+        {
+            capturedRequest = req;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        });
+
+        var handler = new AppSourceHeaderHandler(innerHandler);
+        var client = new HttpClient(handler);
+
+        await client.GetAsync("https://example.com/api/test");
+
+        Assert.NotNull(capturedRequest);
+        Assert.True(capturedRequest.Headers.Contains("X-App-Source"));
+        var headerValues = capturedRequest.Headers.GetValues("X-App-Source");
+        Assert.Equal("HslBikeApp", Assert.Single(headerValues));
+    }
+
+    [Fact]
+    public async Task SendAsync_AddsHeaderToMultipleRequests()
+    {
+        var requestCount = 0;
+        HttpRequestMessage? lastRequest = null;
+
+        var innerHandler = new StubHttpMessageHandler((req, ct) =>
+        {
+            requestCount++;
+            lastRequest = req;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        });
+
+        var handler = new AppSourceHeaderHandler(innerHandler);
+        var client = new HttpClient(handler);
+
+        await client.GetAsync("https://example.com/api/first");
+        await client.GetAsync("https://example.com/api/second");
+        await client.GetAsync("https://example.com/api/third");
+
+        Assert.Equal(3, requestCount);
+        Assert.NotNull(lastRequest);
+        Assert.True(lastRequest.Headers.Contains("X-App-Source"));
+        var headerValues = lastRequest.Headers.GetValues("X-App-Source");
+        Assert.Equal("HslBikeApp", Assert.Single(headerValues));
+    }
+
+    [Fact]
+    public async Task SendAsync_PreservesOtherHeaders()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        var innerHandler = new StubHttpMessageHandler((req, ct) =>
+        {
+            capturedRequest = req;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        });
+
+        var handler = new AppSourceHeaderHandler(innerHandler);
+        var client = new HttpClient(handler);
+        client.DefaultRequestHeaders.Add("Custom-Header", "CustomValue");
+
+        await client.GetAsync("https://example.com/api/test");
+
+        Assert.NotNull(capturedRequest);
+        Assert.True(capturedRequest.Headers.Contains("X-App-Source"));
+        Assert.True(capturedRequest.Headers.Contains("Custom-Header"));
+        Assert.Equal("CustomValue", Assert.Single(capturedRequest.Headers.GetValues("Custom-Header")));
+    }
+}

--- a/tests/HslBikeApp.Tests/Services/StubHttpMessageHandler.cs
+++ b/tests/HslBikeApp.Tests/Services/StubHttpMessageHandler.cs
@@ -1,4 +1,4 @@
-namespace HslBikeApp.Tests.Services;
+namespace HslBikeApp.Tests;
 
 internal sealed class StubHttpMessageHandler : HttpMessageHandler
 {


### PR DESCRIPTION
## Summary

This PR implements issue #14 by adding support for the Azure API Management gateway in front of the backend Function App.

## Changes

### 1. **AppSourceHeaderHandler** (`src/HslBikeApp/Http/AppSourceHeaderHandler.cs`)
   - New `DelegatingHandler` that adds `X-App-Source: HslBikeApp` header to all outgoing HTTP requests
   - Required by APIM for casual-abuse filtering (as per backend issue HslBikeDataAggregator#24)
   - Implemented as a sealed class with two constructors to support both production and testing scenarios

### 2. **Program.cs Updates**
   - Configured `HttpClient` instances with `AppSourceHeaderHandler` for all aggregator services
   - Maintained separate plain `HttpClient` for `CycleLaneService` (calls Helsinki WFS, not the aggregator)
   - Clear separation between aggregator-bound and external API clients

### 3. **API Base URL Update** (`wwwroot/appsettings.json`)
   - Changed from direct Function App URL: `https://func-hsl-bike-data-aggregator-dev.azurewebsites.net`
   - To APIM gateway URL: `https://apim-hsl-bike-data-aggregator-dev.azure-api.net`
   - Removes direct Function App references as required

### 4. **Test Coverage** (`tests/HslBikeApp.Tests/Http/AppSourceHeaderHandlerTests.cs`)
   - Three comprehensive tests covering:
     - Header addition to single requests
     - Header addition across multiple requests
     - Preservation of other custom headers
   - Refactored `StubHttpMessageHandler` to `HslBikeApp.Tests` namespace for reuse

## Testing

✅ All 50 existing tests pass  
✅ 3 new tests added for `AppSourceHeaderHandler`  
✅ Build successful  
✅ Pre-commit hooks passed  

## Dependencies

This PR depends on the backend APIM deployment completed in [HslBikeDataAggregator#24](https://github.com/Kuoste/HslBikeDataAggregator/issues/24) (now closed).

## CORS Verification

As noted in issue #14, no frontend CORS changes are expected since APIM mirrors the existing CORS policy allowing `https://kuoste.github.io`. Verification will be performed after deployment.

Closes #14