### PR TITLE
feat: remove spaces from UI, show bike count in markers with trend chevrons

### DIFF
--- a/src/HslBikeApp/Components/MapView.razor
+++ b/src/HslBikeApp/Components/MapView.razor
@@ -1,3 +1,4 @@
+@using HslBikeApp.Helpers
 @inject AppState State
 @inject IJSRuntime JS
 @implements IAsyncDisposable
@@ -35,8 +36,7 @@
         var markers = State.FilteredStations.Select(s =>
         {
             var trend = State.GetTrend(s.Id);
-            State.BikeChanges.TryGetValue(s.Id, out var change);
-            var badge = GetBadgeText(change, trend);
+            var (badge, badgeColor) = DisplayHelpers.GetBadge(trend);
 
             return new
             {
@@ -45,9 +45,10 @@
                 lon = s.Longitude,
                 name = s.Name,
                 bikes = s.BikesAvailable,
-                spaces = s.SpacesAvailable,
-                color = GetMarkerColor(s),
-                badge
+                capacity = s.Capacity,
+                color = DisplayHelpers.GetMarkerColour(s),
+                badge,
+                badgeColor
             };
         }).ToList();
 
@@ -65,26 +66,6 @@
         {
             await JS.InvokeVoidAsync("MapInterop.clearPolylines");
         }
-    }
-
-    private static string GetMarkerColor(BikeStation s)
-    {
-        if (!s.IsActive) return "#9e9e9e";        // grey
-        if (s.BikesAvailable == 0) return "#d32f2f"; // red
-        if (s.BikesAvailable <= 3) return "#f57c00";  // orange
-        return "#388e3c";                             // green
-    }
-
-    private static string GetBadgeText(int change, AvailabilityTrend trend)
-    {
-        var parts = new List<string>();
-        if (change > 0) parts.Add($"\u2191{change}");
-        else if (change < 0) parts.Add($"\u2193{Math.Abs(change)}");
-
-        if (trend == AvailabilityTrend.RapidDecrease) parts.Add("\u2193\u2193");
-        else if (trend == AvailabilityTrend.RapidIncrease) parts.Add("\u2191\u2191");
-
-        return string.Join(" ", parts);
     }
 
     [JSInvokable]

--- a/src/HslBikeApp/Components/StationDetailPanel.razor
+++ b/src/HslBikeApp/Components/StationDetailPanel.razor
@@ -1,4 +1,5 @@
 @using System.Globalization
+@using HslBikeApp.Helpers
 
 <div class="detail-panel">
     <button class="back-btn" @onclick="OnBack">&#8592; Back to map</button>
@@ -16,17 +17,13 @@
             }
             else
             {
-                <span class="chip @(Station.BikesAvailable == 0 ? "empty" : "bikes")">
-                    &#128690; @Station.BikesAvailable bikes
+                <span class="chip @DisplayHelpers.GetBikeChipClass(Station.BikesAvailable)">
+                    &#128690; @Station.BikesAvailable / @Station.Capacity bikes
                 </span>
-                <span class="chip @(Station.SpacesAvailable == 0 ? "empty" : "spaces")">
-                    P @Station.SpacesAvailable spaces
-                </span>
-                <span class="chip capacity">&#9878; @Station.Capacity total</span>
             }
         </div>
 
-        <div class="trend @GetTrendClass()">@GetTrendText()</div>
+        <div class="trend @DisplayHelpers.GetTrendClass(Trend)">@DisplayHelpers.GetTrendText(Trend)</div>
 
         @if (Sparkline.Count > 1)
         {
@@ -125,24 +122,6 @@
     [Parameter] public EventCallback OnBack { get; set; }
 
     private static readonly CultureInfo InvariantCulture = CultureInfo.InvariantCulture;
-
-    private string GetTrendClass() => Trend switch
-    {
-        AvailabilityTrend.RapidDecrease => "rapid-decrease",
-        AvailabilityTrend.Decreasing => "decreasing",
-        AvailabilityTrend.Increasing => "increasing",
-        AvailabilityTrend.RapidIncrease => "rapid-increase",
-        _ => "stable"
-    };
-
-    private string GetTrendText() => Trend switch
-    {
-        AvailabilityTrend.RapidDecrease => "\u2193\u2193 Bikes decreasing rapidly",
-        AvailabilityTrend.Decreasing => "\u2193 Bikes decreasing",
-        AvailabilityTrend.Increasing => "\u2191 Bikes increasing",
-        AvailabilityTrend.RapidIncrease => "\u2191\u2191 Bikes increasing rapidly",
-        _ => "Stable"
-    };
 
     private string GetSparklinePoints()
     {

--- a/src/HslBikeApp/Components/StationInfoPanel.razor
+++ b/src/HslBikeApp/Components/StationInfoPanel.razor
@@ -1,3 +1,5 @@
+@using HslBikeApp.Helpers
+
 <div class="info-panel">
     <div class="drag-handle"></div>
     <div class="header">
@@ -13,31 +15,12 @@
         }
         else
         {
-            <span class="chip @(Station.BikesAvailable == 0 ? "empty" : "bikes")">
-                &#128690; @Station.BikesAvailable bikes
+            <span class="chip @DisplayHelpers.GetBikeChipClass(Station.BikesAvailable)">
+                &#128690; @Station.BikesAvailable / @Station.Capacity bikes
             </span>
-            <span class="chip @(Station.SpacesAvailable == 0 ? "empty" : "spaces")">
-                P @Station.SpacesAvailable spaces
-            </span>
-            <span class="chip capacity">&#9878; @Station.Capacity total</span>
+            <span class="chip trend-chip @DisplayHelpers.GetTrendClass(Trend)">@DisplayHelpers.GetTrendChevron(Trend)</span>
         }
     </div>
-
-    @if (BikeChange != 0)
-    {
-        <div style="font-size:13px;margin-bottom:8px;">
-            @if (BikeChange > 0)
-            {
-                <span style="color:var(--success);">&#9650; @BikeChange returned</span>
-            }
-            else
-            {
-                <span style="color:var(--error);">&#9660; @Math.Abs(BikeChange) rented</span>
-            }
-        </div>
-    }
-
-    <div class="trend @GetTrendClass()">@GetTrendText()</div>
 
     <div style="margin-top:12px;">
         <button class="btn-primary" @onclick="OnViewDetail">View trip history</button>
@@ -46,26 +29,7 @@
 
 @code {
     [Parameter] public required BikeStation Station { get; set; }
-    [Parameter] public int BikeChange { get; set; }
     [Parameter] public AvailabilityTrend Trend { get; set; }
     [Parameter] public EventCallback OnClose { get; set; }
     [Parameter] public EventCallback OnViewDetail { get; set; }
-
-    private string GetTrendClass() => Trend switch
-    {
-        AvailabilityTrend.RapidDecrease => "rapid-decrease",
-        AvailabilityTrend.Decreasing => "decreasing",
-        AvailabilityTrend.Increasing => "increasing",
-        AvailabilityTrend.RapidIncrease => "rapid-increase",
-        _ => "stable"
-    };
-
-    private string GetTrendText() => Trend switch
-    {
-        AvailabilityTrend.RapidDecrease => "\u2193\u2193 Bikes decreasing rapidly",
-        AvailabilityTrend.Decreasing => "\u2193 Bikes decreasing",
-        AvailabilityTrend.Increasing => "\u2191 Bikes increasing",
-        AvailabilityTrend.RapidIncrease => "\u2191\u2191 Bikes increasing rapidly",
-        _ => "Stable"
-    };
 }

--- a/src/HslBikeApp/Helpers/DisplayHelpers.cs
+++ b/src/HslBikeApp/Helpers/DisplayHelpers.cs
@@ -1,0 +1,63 @@
+using HslBikeApp.Models;
+
+namespace HslBikeApp.Helpers;
+
+/// <summary>
+/// Pure helper methods for station marker colours, trend chevrons and CSS classes.
+/// Shared across MapView, StationInfoPanel and StationDetailPanel.
+/// </summary>
+public static class DisplayHelpers
+{
+    /// <summary>Returns the marker fill colour for the given station.</summary>
+    public static string GetMarkerColour(BikeStation station)
+    {
+        if (!station.IsActive) return "#9e9e9e";        // grey
+        if (station.BikesAvailable == 0) return "#d32f2f"; // red
+        if (station.BikesAvailable <= 3) return "#f57c00";  // orange
+        return "#388e3c";                                   // green
+    }
+
+    /// <summary>Returns a chevron badge string and its colour for map marker badges.</summary>
+    public static (string Badge, string Colour) GetBadge(AvailabilityTrend trend) => trend switch
+    {
+        AvailabilityTrend.RapidDecrease => ("\u00bb\u00bb", "#d32f2f"),
+        AvailabilityTrend.Decreasing => ("\u00bb", "#f57c00"),
+        AvailabilityTrend.Increasing => ("\u00ab", "#388e3c"),
+        AvailabilityTrend.RapidIncrease => ("\u00ab\u00ab", "#009688"),
+        _ => ("", "")
+    };
+
+    /// <summary>Returns a CSS modifier class name for the given trend.</summary>
+    public static string GetTrendClass(AvailabilityTrend trend) => trend switch
+    {
+        AvailabilityTrend.RapidDecrease => "rapid-decrease",
+        AvailabilityTrend.Decreasing => "decreasing",
+        AvailabilityTrend.Increasing => "increasing",
+        AvailabilityTrend.RapidIncrease => "rapid-increase",
+        _ => "stable"
+    };
+
+    /// <summary>Returns a short chevron symbol for the trend (info panel chip).</summary>
+    public static string GetTrendChevron(AvailabilityTrend trend) => trend switch
+    {
+        AvailabilityTrend.RapidDecrease => "\u00bb\u00bb",
+        AvailabilityTrend.Decreasing => "\u00bb",
+        AvailabilityTrend.Increasing => "\u00ab",
+        AvailabilityTrend.RapidIncrease => "\u00ab\u00ab",
+        _ => "="
+    };
+
+    /// <summary>Returns descriptive trend text with chevron prefix (detail panel).</summary>
+    public static string GetTrendText(AvailabilityTrend trend) => trend switch
+    {
+        AvailabilityTrend.RapidDecrease => "\u00bb\u00bb Bikes leaving rapidly",
+        AvailabilityTrend.Decreasing => "\u00bb Bikes leaving",
+        AvailabilityTrend.Increasing => "\u00ab Bikes arriving",
+        AvailabilityTrend.RapidIncrease => "\u00ab\u00ab Bikes arriving rapidly",
+        _ => "Stable"
+    };
+
+    /// <summary>Returns a CSS class for the bike count chip.</summary>
+    public static string GetBikeChipClass(int bikesAvailable) =>
+        bikesAvailable == 0 ? "empty" : "bikes";
+}

--- a/src/HslBikeApp/Pages/Home.razor
+++ b/src/HslBikeApp/Pages/Home.razor
@@ -81,7 +81,6 @@
 @if (State.SelectedStation is not null && !_showDetail)
 {
     <StationInfoPanel Station="State.SelectedStation"
-                      BikeChange="@GetBikeChange(State.SelectedStation.Id)"
                       Trend="@State.GetTrend(State.SelectedStation.Id)"
                       OnClose="OnClosePanel"
                       OnViewDetail="OnViewDetail" />
@@ -123,9 +122,6 @@
         State.OnStateChanged += _stateChangedHandler;
         await State.InitAsync();
     }
-
-    private int GetBikeChange(string stationId) =>
-        State.BikeChanges.TryGetValue(stationId, out var change) ? change : 0;
 
     private async Task RefreshAsync() => await State.RefreshNowAsync();
 

--- a/src/HslBikeApp/wwwroot/css/app.css
+++ b/src/HslBikeApp/wwwroot/css/app.css
@@ -294,17 +294,53 @@ html, body {
 }
 
 .chip.bikes { background: #e8f5e9; color: #2e7d32; }
-.chip.spaces { background: #e3f2fd; color: #1565c0; }
-.chip.capacity { background: #f5f5f5; color: #616161; }
 .chip.empty { background: #ffebee; color: #c62828; }
 .chip.offline { background: #eeeeee; color: #9e9e9e; }
+.chip.trend-chip { font-weight: 700; letter-spacing: 1px; }
+.chip.trend-chip.stable { background: #f5f5f5; color: #616161; }
+.chip.trend-chip.decreasing { background: #fff3e0; color: #e65100; }
+.chip.trend-chip.rapid-decrease { background: #ffebee; color: #c62828; animation: pulse 1.5s infinite; }
+.chip.trend-chip.increasing { background: #e8f5e9; color: #2e7d32; }
+.chip.trend-chip.rapid-increase { background: #e0f2f1; color: #00695c; }
 
 @media (prefers-color-scheme: dark) {
     .chip.bikes { background: #1b5e20; color: #a5d6a7; }
-    .chip.spaces { background: #0d47a1; color: #90caf9; }
-    .chip.capacity { background: #424242; color: #bdbdbd; }
     .chip.empty { background: #b71c1c; color: #ef9a9a; }
     .chip.offline { background: #424242; color: #9e9e9e; }
+    .chip.trend-chip.stable { background: #424242; color: #bdbdbd; }
+    .chip.trend-chip.decreasing { background: #4e342e; color: #ffab91; }
+    .chip.trend-chip.rapid-decrease { background: #b71c1c; color: #ef9a9a; }
+    .chip.trend-chip.increasing { background: #1b5e20; color: #a5d6a7; }
+    .chip.trend-chip.rapid-increase { background: #004d40; color: #80cbc4; }
+}
+
+/* ===== Map markers with bike count ===== */
+.bike-marker-container {
+    background: transparent !important;
+    border: none !important;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.bike-marker {
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-weight: 700;
+    line-height: 1;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+}
+
+.bike-badge {
+    font-size: 12px;
+    font-weight: 800;
+    line-height: 1;
+    margin-top: 1px;
+    text-shadow: 0 0 3px rgba(255, 255, 255, 0.9);
 }
 
 /* ===== Trend indicators ===== */

--- a/src/HslBikeApp/wwwroot/js/map-interop.js
+++ b/src/HslBikeApp/wwwroot/js/map-interop.js
@@ -37,22 +37,26 @@ window.MapInterop = {
 
         for (const m of markers) {
             const isSelected = m.id === this._selectedId;
-            const radius = isSelected ? 14 : 10;
-            const opts = {
-                radius: radius,
-                fillColor: m.color,
-                color: isSelected ? '#000' : '#fff',
-                weight: isSelected ? 3 : 2,
-                opacity: 1,
-                fillOpacity: 0.85
-            };
+            const size = isSelected ? 32 : 26;
+            const borderWidth = isSelected ? 3 : 2;
+            const borderColor = isSelected ? '#000' : '#fff';
+            const fontSize = isSelected ? 13 : 11;
+
+            const html = `<div class="bike-marker" style="width:${size}px;height:${size}px;background:${m.color};border:${borderWidth}px solid ${borderColor};font-size:${fontSize}px;">${m.bikes}</div>` +
+                (m.badge ? `<div class="bike-badge" style="color:${m.badgeColor};">${m.badge}</div>` : '');
+
+            const icon = L.divIcon({
+                className: 'bike-marker-container',
+                html: html,
+                iconSize: [size, size + (m.badge ? 14 : 0)],
+                iconAnchor: [size / 2, size / 2]
+            });
 
             if (this._markers[m.id]) {
                 this._markers[m.id].setLatLng([m.lat, m.lon]);
-                this._markers[m.id].setStyle(opts);
-                this._markers[m.id].setRadius(radius);
+                this._markers[m.id].setIcon(icon);
             } else {
-                const marker = L.circleMarker([m.lat, m.lon], opts).addTo(this._map);
+                const marker = L.marker([m.lat, m.lon], { icon: icon }).addTo(this._map);
                 marker.on('click', (e) => {
                     L.DomEvent.stopPropagation(e);
                     if (this._dotNetRef) {
@@ -62,10 +66,10 @@ window.MapInterop = {
                 this._markers[m.id] = marker;
             }
 
-            // Tooltip with station name and bikes
+            // Tooltip with station name and availability
             this._markers[m.id].bindTooltip(
-                `<b>${m.name}</b><br>${m.bikes} bikes / ${m.spaces} spaces${m.badge ? '<br>' + m.badge : ''}`,
-                { direction: 'top', offset: [0, -10] }
+                `<b>${m.name}</b><br>\ud83d\udeb2 ${m.bikes} / ${m.capacity} bikes${m.badge ? ' <span style="font-weight:700;">' + m.badge + '</span>' : ''}`,
+                { direction: 'top', offset: [0, -size / 2 - 4] }
             );
         }
     },

--- a/tests/HslBikeApp.Tests/Helpers/DisplayHelpersTests.cs
+++ b/tests/HslBikeApp.Tests/Helpers/DisplayHelpersTests.cs
@@ -1,0 +1,121 @@
+using HslBikeApp.Helpers;
+using HslBikeApp.Models;
+
+namespace HslBikeApp.Tests.Helpers;
+
+public class DisplayHelpersTests
+{
+    [Fact]
+    public void GetMarkerColour_InactiveStation_ReturnsGrey()
+    {
+        var station = new BikeStation { Id = "1", Name = "Test", IsActive = false, BikesAvailable = 5 };
+        Assert.Equal("#9e9e9e", DisplayHelpers.GetMarkerColour(station));
+    }
+
+    [Fact]
+    public void GetMarkerColour_ZeroBikes_ReturnsRed()
+    {
+        var station = new BikeStation { Id = "1", Name = "Test", IsActive = true, BikesAvailable = 0 };
+        Assert.Equal("#d32f2f", DisplayHelpers.GetMarkerColour(station));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void GetMarkerColour_LowBikes_ReturnsOrange(int bikes)
+    {
+        var station = new BikeStation { Id = "1", Name = "Test", IsActive = true, BikesAvailable = bikes };
+        Assert.Equal("#f57c00", DisplayHelpers.GetMarkerColour(station));
+    }
+
+    [Theory]
+    [InlineData(4)]
+    [InlineData(10)]
+    [InlineData(20)]
+    public void GetMarkerColour_HighBikes_ReturnsGreen(int bikes)
+    {
+        var station = new BikeStation { Id = "1", Name = "Test", IsActive = true, BikesAvailable = bikes };
+        Assert.Equal("#388e3c", DisplayHelpers.GetMarkerColour(station));
+    }
+
+    [Theory]
+    [InlineData(AvailabilityTrend.RapidDecrease, "\u00bb\u00bb", "#d32f2f")]
+    [InlineData(AvailabilityTrend.Decreasing, "\u00bb", "#f57c00")]
+    [InlineData(AvailabilityTrend.Increasing, "\u00ab", "#388e3c")]
+    [InlineData(AvailabilityTrend.RapidIncrease, "\u00ab\u00ab", "#009688")]
+    [InlineData(AvailabilityTrend.Stable, "", "")]
+    public void GetBadge_ReturnsExpectedChevronAndColour(AvailabilityTrend trend, string expectedBadge, string expectedColour)
+    {
+        var (badge, colour) = DisplayHelpers.GetBadge(trend);
+        Assert.Equal(expectedBadge, badge);
+        Assert.Equal(expectedColour, colour);
+    }
+
+    [Theory]
+    [InlineData(AvailabilityTrend.RapidDecrease, "rapid-decrease")]
+    [InlineData(AvailabilityTrend.Decreasing, "decreasing")]
+    [InlineData(AvailabilityTrend.Increasing, "increasing")]
+    [InlineData(AvailabilityTrend.RapidIncrease, "rapid-increase")]
+    [InlineData(AvailabilityTrend.Stable, "stable")]
+    public void GetTrendClass_ReturnsExpectedCssClass(AvailabilityTrend trend, string expectedClass)
+    {
+        Assert.Equal(expectedClass, DisplayHelpers.GetTrendClass(trend));
+    }
+
+    [Theory]
+    [InlineData(AvailabilityTrend.RapidDecrease, "\u00bb\u00bb")]
+    [InlineData(AvailabilityTrend.Decreasing, "\u00bb")]
+    [InlineData(AvailabilityTrend.Increasing, "\u00ab")]
+    [InlineData(AvailabilityTrend.RapidIncrease, "\u00ab\u00ab")]
+    [InlineData(AvailabilityTrend.Stable, "=")]
+    public void GetTrendChevron_ReturnsExpectedSymbol(AvailabilityTrend trend, string expectedChevron)
+    {
+        Assert.Equal(expectedChevron, DisplayHelpers.GetTrendChevron(trend));
+    }
+
+    [Fact]
+    public void GetTrendText_Stable_ReturnsStable()
+    {
+        Assert.Equal("Stable", DisplayHelpers.GetTrendText(AvailabilityTrend.Stable));
+    }
+
+    [Fact]
+    public void GetTrendText_Decreasing_ContainsBikesLeaving()
+    {
+        var text = DisplayHelpers.GetTrendText(AvailabilityTrend.Decreasing);
+        Assert.Contains("Bikes leaving", text);
+        Assert.StartsWith("\u00bb", text);
+    }
+
+    [Fact]
+    public void GetTrendText_Increasing_ContainsBikesArriving()
+    {
+        var text = DisplayHelpers.GetTrendText(AvailabilityTrend.Increasing);
+        Assert.Contains("Bikes arriving", text);
+        Assert.StartsWith("\u00ab", text);
+    }
+
+    [Fact]
+    public void GetTrendText_RapidDecrease_ContainsRapidly()
+    {
+        var text = DisplayHelpers.GetTrendText(AvailabilityTrend.RapidDecrease);
+        Assert.Contains("rapidly", text);
+    }
+
+    [Fact]
+    public void GetTrendText_RapidIncrease_ContainsRapidly()
+    {
+        var text = DisplayHelpers.GetTrendText(AvailabilityTrend.RapidIncrease);
+        Assert.Contains("rapidly", text);
+    }
+
+    [Theory]
+    [InlineData(0, "empty")]
+    [InlineData(1, "bikes")]
+    [InlineData(10, "bikes")]
+    public void GetBikeChipClass_ReturnsExpectedClass(int bikesAvailable, string expectedClass)
+    {
+        Assert.Equal(expectedClass, DisplayHelpers.GetBikeChipClass(bikesAvailable));
+    }
+}


### PR DESCRIPTION
## Summary

Remove the spaces display from the UI and replace it with a cleaner bike count and trend chevron experience.

### Changes

**UI — Station panels**
- Remove the "spaces available" chip from `StationInfoPanel` and `StationDetailPanel`
- Show **"🚲 X / Y bikes"** format instead (bikes available / capacity)
- Replace arrow trend indicators (↑↓) with chevron symbols: `»` `«` `»»` `««`
- Trend text in the detail panel now reads e.g. "» Bikes leaving" or "« Bikes arriving"

**Map markers**
- Convert from `L.circleMarker` (plain coloured dots) to `L.divIcon` with the **bike count number displayed inside** the marker circle
- Optional chevron badge overlay for stations with active trends
- Tooltip shows "🚲 X / Y bikes"

**Code quality**
- Extract shared display logic (marker colours, trend classes, chevrons, chip classes) into `DisplayHelpers.cs` — removes duplication across three Razor components
- Add **28 new unit tests** covering all display helper methods

**CSS**
- Remove `.chip.spaces` and `.chip.capacity` styles
- Add `.bike-marker-container`, `.bike-marker`, `.bike-badge`, `.chip.trend-chip` styles with dark mode support

### Files changed (8)
| File | Change |
|---|---|
| `src/HslBikeApp/Helpers/DisplayHelpers.cs` | **New** — shared pure helper methods |
| `src/HslBikeApp/Components/MapView.razor` | Delegates to `DisplayHelpers`, removed old private methods |
| `src/HslBikeApp/Components/StationInfoPanel.razor` | Removed spaces chip + `BikeChange` param, uses `DisplayHelpers` |
| `src/HslBikeApp/Components/StationDetailPanel.razor` | Removed spaces chip, chevron trend text, uses `DisplayHelpers` |
| `src/HslBikeApp/Pages/Home.razor` | Removed `BikeChange` parameter passing |
| `src/HslBikeApp/wwwroot/js/map-interop.js` | `divIcon` markers with bike count inside |
| `src/HslBikeApp/wwwroot/css/app.css` | New marker + trend styles, removed old styles |
| `tests/HslBikeApp.Tests/Helpers/DisplayHelpersTests.cs` | **New** — 28 unit tests |

### Test results
All 81 tests pass (53 existing + 28 new).

Closes #12