### PR TITLE
Render open data sources on the map with a details panel (#25)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,13 +46,13 @@ Helsinki city bike availability app. Two repositories form the full system:
 - `DemandProfile` — hourly availability data (hour 0–23 → averageBikesAvailable)
 - `DestinationRow` / `DestinationTable` — popular destinations from HSL open history data
 - `TrendSummary` / `TrendThresholds` / `AvailabilityTrend` — trend calculation models
-- `OpenDataTimeSeries` — sourceId, displayName, lat, lon, attributionUrl, timestamps[], values[] (double; `-1` = unavailable/out of season)
+- `OpenDataTimeSeries` — sourceId, displayName, lat, lon, attributionUrl, optional unit, optional description, timestamps[], values[] (double; `-1` = unavailable/out of season). `LatestAvailable()` returns the most recent non-sentinel sample.
 - `CycleLane` — cycle lane geometry
 
 ## Frontend Architecture (this repo)
 
 - **State**: singleton AppState with OnStateChanged event; components subscribe in OnInitialized/OnAfterRenderAsync and unsubscribe on dispose.
-- **Services**: `StationService`, `LiveStationService`, `SnapshotService`, `StatisticsService`, `CycleLaneService` — each takes HttpClient via constructor. `LiveStationService` maintains a live (timestamp, counts) pair separate from the snapshot history.
+- **Services**: `StationService`, `LiveStationService`, `SnapshotService`, `StatisticsService`, `OpenDataService`, `CycleLaneService` — each takes HttpClient via constructor. `LiveStationService` maintains a live (timestamp, counts) pair separate from the snapshot history. `OpenDataService` fetches generic open data time series rendered through `OpenDataDetailPanel`.
 - **Map**: Leaflet.js via JS interop (wwwroot/js/map-interop.js), driven by MapView.razor.
 - **Pages**: single-page app with Home.razor as the main page.
 

--- a/src/HslBikeApp/Components/MapView.razor
+++ b/src/HslBikeApp/Components/MapView.razor
@@ -55,6 +55,26 @@
         await JS.InvokeVoidAsync("MapInterop.updateMarkers",
             System.Text.Json.JsonSerializer.Serialize(markers));
 
+        // Open data sources
+        var openDataMarkers = State.OpenDataSeries.Select(series =>
+        {
+            var latest = series.LatestAvailable();
+            var unit = string.IsNullOrWhiteSpace(series.Unit) ? "" : " " + series.Unit;
+            var tooltip = latest is { } point
+                ? $"<b>{series.DisplayName}</b><br>{FormatValue(point.Value)}{unit}"
+                : $"<b>{series.DisplayName}</b><br>Currently unavailable";
+            return new
+            {
+                id = series.SourceId,
+                lat = series.Lat,
+                lon = series.Lon,
+                tooltip
+            };
+        }).ToList();
+
+        await JS.InvokeVoidAsync("MapInterop.updateOpenDataMarkers",
+            System.Text.Json.JsonSerializer.Serialize(openDataMarkers));
+
         // Cycle lanes
         if (State.ShowCycleLanes && State.CycleLanes.Count > 0)
         {
@@ -107,7 +127,17 @@
     }
 
     [JSInvokable]
+    public void OnOpenDataMarkerClicked(string sourceId) => State.SelectOpenDataSource(sourceId);
+
+    [JSInvokable]
     public void OnMapClicked() => State.ClearSelection();
+
+    private static string FormatValue(double value)
+    {
+        if (Math.Abs(value - Math.Round(value)) < 0.0001)
+            return ((long)Math.Round(value)).ToString(System.Globalization.CultureInfo.InvariantCulture);
+        return value.ToString("0.#", System.Globalization.CultureInfo.InvariantCulture);
+    }
 
     public async ValueTask DisposeAsync()
     {

--- a/src/HslBikeApp/Components/OpenDataDetailPanel.razor
+++ b/src/HslBikeApp/Components/OpenDataDetailPanel.razor
@@ -39,13 +39,24 @@
 
         @if (sparkline is not null)
         {
-            <svg class="open-data-sparkline" viewBox="0 0 200 60" preserveAspectRatio="none"
-                 aria-label="@($"{Series.DisplayName} history")">
-                <polyline points="@sparkline.LinePoints" />
-            </svg>
-            <div class="open-data-sparkline-axis">
-                <span>@FormatLocalTime(sparkline.FirstTimestamp)</span>
-                <span>@FormatLocalTime(sparkline.LastTimestamp)</span>
+            <div class="snapshot-chart-layout open-data-chart-layout">
+                <div class="snapshot-y-axis">
+                    <span>@FormatValue(sparkline.Max)</span>
+                    <span>@FormatValue(sparkline.Mid)</span>
+                    <span>@FormatValue(sparkline.Min)</span>
+                </div>
+                <div class="snapshot-chart-wrapper">
+                    <svg class="open-data-sparkline" viewBox="0 0 200 60" preserveAspectRatio="none"
+                         aria-label="@($"{Series.DisplayName} history")">
+                        <polyline points="@sparkline.LinePoints" />
+                    </svg>
+                    <div class="snapshot-x-axis open-data-x-axis">
+                        @foreach (var tick in sparkline.XTicks)
+                        {
+                            <span style="left:@F(tick.Percent)%;">@tick.Label</span>
+                        }
+                    </div>
+                </div>
             </div>
         }
     </div>
@@ -80,6 +91,7 @@
 
         var min = available.Min(p => p.Value);
         var max = available.Max(p => p.Value);
+        var mid = (min + max) / 2;
         var range = max - min;
         if (range <= 0) range = 1;
 
@@ -88,15 +100,21 @@
         foreach (var (index, value) in available)
         {
             var x = lastIndex == 0 ? 0 : (double)index / lastIndex * 200;
-            // SVG y inverted: higher value = smaller y
             var y = 55 - (value - min) / range * 50;
             points.Add(string.Create(CultureInfo.InvariantCulture, $"{x:0.##},{y:0.##}"));
         }
 
-        return new SparklineData(
-            string.Join(' ', points),
-            Series.Timestamps[0],
-            Series.Timestamps[^1]);
+        // 4 evenly-spaced x-axis ticks across the full timestamp array
+        var tickCount = Math.Min(4, Series.Timestamps.Count);
+        var xTicks = new List<XTick>(tickCount);
+        for (var i = 0; i < tickCount; i++)
+        {
+            var fraction = tickCount == 1 ? 0.0 : (double)i / (tickCount - 1);
+            var tsIndex = (int)Math.Round(fraction * (Series.Timestamps.Count - 1));
+            xTicks.Add(new XTick(FormatLocalTime(Series.Timestamps[tsIndex]), fraction * 100));
+        }
+
+        return new SparklineData(string.Join(' ', points), min, mid, max, xTicks);
     }
 
     private static string FormatValue(double value)
@@ -109,5 +127,14 @@
     private static string FormatLocalTime(DateTimeOffset value) =>
         value.ToLocalTime().ToString("HH:mm", CultureInfo.CurrentCulture);
 
-    private sealed record SparklineData(string LinePoints, DateTimeOffset FirstTimestamp, DateTimeOffset LastTimestamp);
+    private static string F(double value) =>
+        value.ToString("0.##", CultureInfo.InvariantCulture);
+
+    private sealed record XTick(string Label, double Percent);
+    private sealed record SparklineData(
+        string LinePoints,
+        double Min,
+        double Mid,
+        double Max,
+        List<XTick> XTicks);
 }

--- a/src/HslBikeApp/Components/OpenDataDetailPanel.razor
+++ b/src/HslBikeApp/Components/OpenDataDetailPanel.razor
@@ -1,0 +1,113 @@
+@using System.Globalization
+@using HslBikeApp.Models
+
+@{
+    var latest = Series.LatestAvailable();
+    var sparkline = BuildSparkline();
+}
+
+<div class="detail-panel">
+    <div class="drag-handle" aria-hidden="true"></div>
+
+    <div class="detail-panel-header">
+        <div class="detail-panel-heading">
+            <h2>@Series.DisplayName</h2>
+            @if (!string.IsNullOrWhiteSpace(Series.Description))
+            {
+                <div class="meta">@Series.Description</div>
+            }
+        </div>
+        <button class="close-btn" @onclick="OnClose" aria-label="Close source details">&#10005;</button>
+    </div>
+
+    <div class="detail-card open-data-value-card">
+        @if (latest is { } point)
+        {
+            <div class="open-data-value">
+                <span class="open-data-value-number">@FormatValue(point.Value)</span>
+                @if (!string.IsNullOrWhiteSpace(Series.Unit))
+                {
+                    <span class="open-data-value-unit">@Series.Unit</span>
+                }
+            </div>
+            <div class="open-data-updated">Updated @FormatLocalTime(point.Timestamp)</div>
+        }
+        else
+        {
+            <div class="open-data-value open-data-value-unavailable">Currently unavailable</div>
+        }
+
+        @if (sparkline is not null)
+        {
+            <svg class="open-data-sparkline" viewBox="0 0 200 60" preserveAspectRatio="none"
+                 aria-label="@($"{Series.DisplayName} history")">
+                <polyline points="@sparkline.LinePoints" />
+            </svg>
+            <div class="open-data-sparkline-axis">
+                <span>@FormatLocalTime(sparkline.FirstTimestamp)</span>
+                <span>@FormatLocalTime(sparkline.LastTimestamp)</span>
+            </div>
+        }
+    </div>
+
+    @if (!string.IsNullOrWhiteSpace(Series.AttributionUrl))
+    {
+        <div class="open-data-attribution">
+            Source:
+            <a href="@Series.AttributionUrl" target="_blank" rel="noopener noreferrer">@Series.AttributionUrl</a>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired]
+    public OpenDataTimeSeries Series { get; set; } = default!;
+
+    [Parameter]
+    public EventCallback OnClose { get; set; }
+
+    private SparklineData? BuildSparkline()
+    {
+        if (Series.Values.Count < 2) return null;
+
+        var available = new List<(int Index, double Value)>(Series.Values.Count);
+        for (var index = 0; index < Series.Values.Count; index++)
+        {
+            if (Series.Values[index] != OpenDataTimeSeries.UnavailableSentinel)
+                available.Add((index, Series.Values[index]));
+        }
+        if (available.Count < 2) return null;
+
+        var min = available.Min(p => p.Value);
+        var max = available.Max(p => p.Value);
+        var range = max - min;
+        if (range <= 0) range = 1;
+
+        var lastIndex = Series.Values.Count - 1;
+        var points = new List<string>(available.Count);
+        foreach (var (index, value) in available)
+        {
+            var x = lastIndex == 0 ? 0 : (double)index / lastIndex * 200;
+            // SVG y inverted: higher value = smaller y
+            var y = 55 - (value - min) / range * 50;
+            points.Add(string.Create(CultureInfo.InvariantCulture, $"{x:0.##},{y:0.##}"));
+        }
+
+        return new SparklineData(
+            string.Join(' ', points),
+            Series.Timestamps[0],
+            Series.Timestamps[^1]);
+    }
+
+    private static string FormatValue(double value)
+    {
+        if (Math.Abs(value - Math.Round(value)) < 0.0001)
+            return ((long)Math.Round(value)).ToString("N0", CultureInfo.CurrentCulture);
+        return value.ToString("0.#", CultureInfo.CurrentCulture);
+    }
+
+    private static string FormatLocalTime(DateTimeOffset value) =>
+        value.ToLocalTime().ToString("HH:mm", CultureInfo.CurrentCulture);
+
+    private sealed record SparklineData(string LinePoints, DateTimeOffset FirstTimestamp, DateTimeOffset LastTimestamp);
+}

--- a/src/HslBikeApp/Models/OpenDataTimeSeries.cs
+++ b/src/HslBikeApp/Models/OpenDataTimeSeries.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace HslBikeApp.Models;
+
+public sealed record OpenDataTimeSeries
+{
+    public const double UnavailableSentinel = -1;
+
+    [JsonPropertyName("sourceId")]
+    public required string SourceId { get; init; }
+
+    [JsonPropertyName("displayName")]
+    public required string DisplayName { get; init; }
+
+    [JsonPropertyName("lat")]
+    public required double Lat { get; init; }
+
+    [JsonPropertyName("lon")]
+    public required double Lon { get; init; }
+
+    [JsonPropertyName("attributionUrl")]
+    public required string AttributionUrl { get; init; }
+
+    [JsonPropertyName("unit")]
+    public string? Unit { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("timestamps")]
+    public required IReadOnlyList<DateTimeOffset> Timestamps { get; init; }
+
+    [JsonPropertyName("values")]
+    public required IReadOnlyList<double> Values { get; init; }
+
+    public (DateTimeOffset Timestamp, double Value)? LatestAvailable()
+    {
+        for (var index = Values.Count - 1; index >= 0; index--)
+        {
+            if (Values[index] != UnavailableSentinel)
+                return (Timestamps[index], Values[index]);
+        }
+        return null;
+    }
+}

--- a/src/HslBikeApp/Pages/Home.razor
+++ b/src/HslBikeApp/Pages/Home.razor
@@ -78,6 +78,11 @@
     </button>
 </div>
 
+@if (State.SelectedOpenDataSeries is not null)
+{
+    <OpenDataDetailPanel Series="State.SelectedOpenDataSeries" OnClose="OnCloseOpenDataPanel" />
+}
+
 @if (State.SelectedStation is not null)
 {
     <StationDetailPanel Station="State.SelectedStation"
@@ -123,6 +128,7 @@
     private async Task RefreshAsync() => await State.RefreshNowAsync();
 
     private void OnClosePanel() => State.ClearSelection();
+    private void OnCloseOpenDataPanel() => State.ClearOpenDataSelection();
 
     private void ToggleSearch()
     {

--- a/src/HslBikeApp/Program.cs
+++ b/src/HslBikeApp/Program.cs
@@ -22,6 +22,7 @@ builder.Services.AddSingleton(new StatisticsService(httpClientWithHeaders, aggre
 builder.Services.AddSingleton(new CycleLaneService(plainHttpClient));
 builder.Services.AddSingleton(new SnapshotService(httpClientWithHeaders, aggregatorBaseUrl));
 builder.Services.AddSingleton(new LiveStationService(httpClientWithHeaders, aggregatorBaseUrl));
+builder.Services.AddSingleton(new OpenDataService(httpClientWithHeaders, aggregatorBaseUrl));
 builder.Services.AddSingleton<AppState>();
 
 await builder.Build().RunAsync();

--- a/src/HslBikeApp/Services/OpenDataService.cs
+++ b/src/HslBikeApp/Services/OpenDataService.cs
@@ -1,0 +1,62 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using HslBikeApp.Models;
+
+namespace HslBikeApp.Services;
+
+public class OpenDataService
+{
+    private readonly HttpClient _http;
+    private readonly string _openDataUrl;
+
+    public bool LastFetchSucceeded { get; private set; }
+    public string? LastErrorMessage { get; private set; }
+
+    public OpenDataService(HttpClient http, string baseUrl)
+    {
+        ArgumentNullException.ThrowIfNull(http);
+
+        if (string.IsNullOrWhiteSpace(baseUrl))
+            throw new ArgumentException("Aggregator base URL must be configured.", nameof(baseUrl));
+
+        _http = http;
+        _openDataUrl = $"{baseUrl.TrimEnd('/')}/api/open-data";
+    }
+
+    public async Task<List<OpenDataTimeSeries>> FetchOpenDataAsync()
+    {
+        LastFetchSucceeded = false;
+        LastErrorMessage = null;
+
+        try
+        {
+            var response = await _http.GetAsync(_openDataUrl);
+            response.EnsureSuccessStatusCode();
+
+            LastFetchSucceeded = true;
+            return await response.Content.ReadFromJsonAsync<List<OpenDataTimeSeries>>() ?? [];
+        }
+        catch (HttpRequestException ex)
+        {
+            LastErrorMessage = CreateHttpErrorMessage(ex.StatusCode);
+            return [];
+        }
+        catch (JsonException)
+        {
+            LastErrorMessage = $"Could not load open data from the aggregator backend. GET {_openDataUrl} did not return valid JSON.";
+            return [];
+        }
+    }
+
+    private string CreateHttpErrorMessage(HttpStatusCode? statusCode)
+    {
+        if (statusCode is HttpStatusCode.NotFound)
+            return $"Could not load open data from the aggregator backend. GET {_openDataUrl} returned 404 Not Found. Check AggregatorBaseUrl in wwwroot/appsettings.json.";
+
+        if (statusCode is not null)
+            return $"Could not load open data from the aggregator backend. GET {_openDataUrl} returned {(int)statusCode} {statusCode}.";
+
+        return $"Could not load open data from the aggregator backend. GET {_openDataUrl} failed.";
+    }
+}

--- a/src/HslBikeApp/State/AppState.cs
+++ b/src/HslBikeApp/State/AppState.cs
@@ -11,15 +11,18 @@ public class AppState : IAsyncDisposable
     private readonly CycleLaneService _cycleLaneService;
     private readonly SnapshotService _snapshotService;
     private readonly LiveStationService _liveStationService;
+    private readonly OpenDataService _openDataService;
     private readonly IJSRuntime _js;
 
     // --------------- scheduling ---------------
     private const int LivePollIntervalMs = 30_000;
     private const int SnapshotBufferSeconds = 50;
     private const int SnapshotRetrySeconds = 30;
+    private const int OpenDataPollIntervalMs = 10 * 60 * 1000;
 
     private Timer? _livePollTimer;
     private Timer? _snapshotRefreshTimer;
+    private Timer? _openDataPollTimer;
     private bool _tabVisible = true;
     private DotNetObjectReference<AppState>? _dotNetRef;
 
@@ -61,6 +64,11 @@ public class AppState : IAsyncDisposable
     public bool ShowCycleLanes { get; private set; }
     public bool IsLoadingCycleLanes { get; private set; }
 
+    // --------------- open data ---------------
+    public List<OpenDataTimeSeries> OpenDataSeries { get; private set; } = [];
+    public OpenDataTimeSeries? SelectedOpenDataSeries { get; private set; }
+    public bool IsLoadingOpenData { get; private set; }
+
     // --------------- change tracking ---------------
     public Dictionary<string, int> BikeChanges { get; private set; } = new();
 
@@ -72,6 +80,7 @@ public class AppState : IAsyncDisposable
         CycleLaneService cycleLaneService,
         SnapshotService snapshotService,
         LiveStationService liveStationService,
+        OpenDataService openDataService,
         IJSRuntime js)
     {
         _stationService = stationService;
@@ -79,6 +88,7 @@ public class AppState : IAsyncDisposable
         _cycleLaneService = cycleLaneService;
         _snapshotService = snapshotService;
         _liveStationService = liveStationService;
+        _openDataService = openDataService;
         _js = js;
     }
 
@@ -89,8 +99,73 @@ public class AppState : IAsyncDisposable
         ScheduleNextSnapshotRefresh();
         StartLivePoll();
 
+        _ = RefreshOpenDataAsync();
+        StartOpenDataPoll();
+
         _dotNetRef = DotNetObjectReference.Create(this);
         await _js.InvokeVoidAsync("VisibilityInterop.register", _dotNetRef);
+    }
+
+    /// <summary>Refreshes open data from <c>GET /api/open-data</c>.</summary>
+    public async Task RefreshOpenDataAsync()
+    {
+        IsLoadingOpenData = true;
+        NotifyStateChanged();
+
+        try
+        {
+            OpenDataSeries = await _openDataService.FetchOpenDataAsync();
+
+            if (SelectedOpenDataSeries is not null)
+            {
+                SelectedOpenDataSeries = OpenDataSeries
+                    .FirstOrDefault(series => series.SourceId == SelectedOpenDataSeries.SourceId);
+            }
+        }
+        catch
+        {
+            // Failures are non-fatal; the panel surfaces nothing rather than blocking the map.
+            OpenDataSeries = [];
+        }
+        finally
+        {
+            IsLoadingOpenData = false;
+            NotifyStateChanged();
+        }
+    }
+
+    public void SelectOpenDataSource(string sourceId)
+    {
+        var series = OpenDataSeries.FirstOrDefault(s => s.SourceId == sourceId);
+        if (series is null) return;
+
+        SelectedOpenDataSeries = series;
+        // Clear any station selection so the two detail panels never overlap.
+        SelectedStation = null;
+        Destinations = [];
+        Statistics = null;
+        NotifyStateChanged();
+    }
+
+    public void ClearOpenDataSelection()
+    {
+        if (SelectedOpenDataSeries is null) return;
+        SelectedOpenDataSeries = null;
+        NotifyStateChanged();
+    }
+
+    private void StartOpenDataPoll()
+    {
+        _openDataPollTimer?.Dispose();
+        _openDataPollTimer = new Timer(
+            async _ =>
+            {
+                if (!_tabVisible) return;
+                await RefreshOpenDataAsync();
+            },
+            null,
+            OpenDataPollIntervalMs,
+            OpenDataPollIntervalMs);
     }
 
     public void SetSearchQuery(string query)
@@ -229,6 +304,8 @@ public class AppState : IAsyncDisposable
         SelectedStation = station;
         Destinations = [];
         Statistics = null;
+        // Clear any open data selection so the two detail panels never overlap.
+        SelectedOpenDataSeries = null;
         NotifyStateChanged();
     }
 
@@ -266,6 +343,7 @@ public class AppState : IAsyncDisposable
         Destinations = [];
         Statistics = null;
         IsLoadingStatistics = false;
+        SelectedOpenDataSeries = null;
         NotifyStateChanged();
     }
 
@@ -336,6 +414,7 @@ public class AppState : IAsyncDisposable
     {
         _livePollTimer?.Dispose();
         _snapshotRefreshTimer?.Dispose();
+        _openDataPollTimer?.Dispose();
 
         if (_dotNetRef is not null)
         {

--- a/src/HslBikeApp/wwwroot/css/app.css
+++ b/src/HslBikeApp/wwwroot/css/app.css
@@ -738,6 +738,15 @@ html, body {
 }
 
 /* ===== Open data panel ===== */
+.open-data-chart-layout {
+    margin-top: 14px;
+}
+
+.open-data-chart-layout .snapshot-y-axis {
+    /* chart is 80px tall; x-axis below is 46px — match station panel padding */
+    padding: 3px 0 50px;
+}
+
 .open-data-value-card {
     text-align: center;
     padding: 22px 14px;
@@ -776,8 +785,7 @@ html, body {
 
 .open-data-sparkline {
     width: 100%;
-    height: 60px;
-    margin-top: 14px;
+    height: 80px;
     display: block;
 }
 
@@ -790,13 +798,6 @@ html, body {
     stroke-linecap: round;
 }
 
-.open-data-sparkline-axis {
-    display: flex;
-    justify-content: space-between;
-    color: var(--text-secondary);
-    font-size: 11px;
-    margin-top: 4px;
-}
 
 .open-data-attribution {
     font-size: 12px;

--- a/src/HslBikeApp/wwwroot/css/app.css
+++ b/src/HslBikeApp/wwwroot/css/app.css
@@ -737,6 +737,77 @@ html, body {
     to { transform: translateY(0); }
 }
 
+/* ===== Open data panel ===== */
+.open-data-value-card {
+    text-align: center;
+    padding: 22px 14px;
+}
+
+.open-data-value {
+    display: flex;
+    align-items: baseline;
+    justify-content: center;
+    gap: 8px;
+}
+
+.open-data-value-number {
+    font-size: 42px;
+    font-weight: 700;
+    color: var(--text);
+    line-height: 1;
+}
+
+.open-data-value-unit {
+    font-size: 16px;
+    color: var(--text-secondary);
+}
+
+.open-data-value-unavailable {
+    font-size: 18px;
+    color: var(--text-secondary);
+    font-style: italic;
+}
+
+.open-data-updated {
+    margin-top: 6px;
+    color: var(--text-secondary);
+    font-size: 12px;
+}
+
+.open-data-sparkline {
+    width: 100%;
+    height: 60px;
+    margin-top: 14px;
+    display: block;
+}
+
+.open-data-sparkline polyline {
+    fill: none;
+    stroke: var(--primary);
+    stroke-width: 2;
+    vector-effect: non-scaling-stroke;
+    stroke-linejoin: round;
+    stroke-linecap: round;
+}
+
+.open-data-sparkline-axis {
+    display: flex;
+    justify-content: space-between;
+    color: var(--text-secondary);
+    font-size: 11px;
+    margin-top: 4px;
+}
+
+.open-data-attribution {
+    font-size: 12px;
+    color: var(--text-secondary);
+    word-break: break-all;
+}
+
+.open-data-attribution a {
+    color: var(--primary);
+}
+
 /* ===== Loading ===== */
 .loading-screen {
     display: flex;

--- a/src/HslBikeApp/wwwroot/js/map-interop.js
+++ b/src/HslBikeApp/wwwroot/js/map-interop.js
@@ -4,6 +4,7 @@ window.MapInterop = {
     _markers: {},
     _polylines: [],
     _destinationLines: [],
+    _openDataMarkers: {},
     _dotNetRef: null,
     _selectedId: null,
 
@@ -121,6 +122,55 @@ window.MapInterop = {
             this._map.removeLayer(line);
         }
         this._destinationLines = [];
+    },
+
+    updateOpenDataMarkers: function (markersJson) {
+        const markers = JSON.parse(markersJson);
+        const currentIds = new Set(markers.map(m => m.id));
+
+        for (const id of Object.keys(this._openDataMarkers)) {
+            if (!currentIds.has(id)) {
+                this._map.removeLayer(this._openDataMarkers[id]);
+                delete this._openDataMarkers[id];
+            }
+        }
+
+        for (const m of markers) {
+            if (this._openDataMarkers[m.id]) {
+                this._openDataMarkers[m.id].setLatLng([m.lat, m.lon]);
+                if (m.tooltip) this._openDataMarkers[m.id].bindTooltip(m.tooltip, { direction: 'top' });
+                continue;
+            }
+
+            const marker = L.circleMarker([m.lat, m.lon], {
+                radius: 9,
+                color: '#ffffff',
+                weight: 2,
+                fillColor: '#1976d2',
+                fillOpacity: 0.95,
+                className: 'open-data-marker'
+            }).addTo(this._map);
+
+            marker.on('click', (e) => {
+                L.DomEvent.stopPropagation(e);
+                if (this._dotNetRef) {
+                    this._dotNetRef.invokeMethodAsync('OnOpenDataMarkerClicked', m.id);
+                }
+            });
+
+            if (m.tooltip) {
+                marker.bindTooltip(m.tooltip, { direction: 'top' });
+            }
+
+            this._openDataMarkers[m.id] = marker;
+        }
+    },
+
+    clearOpenDataMarkers: function () {
+        for (const id of Object.keys(this._openDataMarkers)) {
+            this._map.removeLayer(this._openDataMarkers[id]);
+        }
+        this._openDataMarkers = {};
     },
 
     invalidateSize: function () {

--- a/tests/HslBikeApp.Tests/Models/OpenDataTimeSeriesTests.cs
+++ b/tests/HslBikeApp.Tests/Models/OpenDataTimeSeriesTests.cs
@@ -1,0 +1,77 @@
+using HslBikeApp.Models;
+
+namespace HslBikeApp.Tests.Models;
+
+public class OpenDataTimeSeriesTests
+{
+    [Fact]
+    public void LatestAvailable_WhenAllValuesAvailable_ReturnsLastEntry()
+    {
+        var series = CreateSeries(
+            timestamps:
+            [
+                new DateTimeOffset(2026, 5, 18, 10, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2026, 5, 18, 10, 15, 0, TimeSpan.Zero)
+            ],
+            values: [180, 192]);
+
+        var latest = series.LatestAvailable();
+
+        Assert.NotNull(latest);
+        Assert.Equal(new DateTimeOffset(2026, 5, 18, 10, 15, 0, TimeSpan.Zero), latest.Value.Timestamp);
+        Assert.Equal(192, latest.Value.Value);
+    }
+
+    [Fact]
+    public void LatestAvailable_WhenLatestValueIsSentinel_SkipsToPreviousAvailable()
+    {
+        var series = CreateSeries(
+            timestamps:
+            [
+                new DateTimeOffset(2026, 5, 18, 10, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2026, 5, 18, 10, 15, 0, TimeSpan.Zero),
+                new DateTimeOffset(2026, 5, 18, 10, 30, 0, TimeSpan.Zero)
+            ],
+            values: [180, 192, OpenDataTimeSeries.UnavailableSentinel]);
+
+        var latest = series.LatestAvailable();
+
+        Assert.NotNull(latest);
+        Assert.Equal(new DateTimeOffset(2026, 5, 18, 10, 15, 0, TimeSpan.Zero), latest.Value.Timestamp);
+        Assert.Equal(192, latest.Value.Value);
+    }
+
+    [Fact]
+    public void LatestAvailable_WhenAllValuesAreSentinel_ReturnsNull()
+    {
+        var series = CreateSeries(
+            timestamps:
+            [
+                new DateTimeOffset(2026, 5, 18, 10, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2026, 5, 18, 10, 15, 0, TimeSpan.Zero)
+            ],
+            values: [OpenDataTimeSeries.UnavailableSentinel, OpenDataTimeSeries.UnavailableSentinel]);
+
+        Assert.Null(series.LatestAvailable());
+    }
+
+    [Fact]
+    public void LatestAvailable_WhenSeriesIsEmpty_ReturnsNull()
+    {
+        var series = CreateSeries(timestamps: [], values: []);
+
+        Assert.Null(series.LatestAvailable());
+    }
+
+    private static OpenDataTimeSeries CreateSeries(IReadOnlyList<DateTimeOffset> timestamps, IReadOnlyList<double> values) =>
+        new()
+        {
+            SourceId = "test",
+            DisplayName = "Test",
+            Lat = 60.0,
+            Lon = 25.0,
+            AttributionUrl = "https://example.com",
+            Timestamps = timestamps,
+            Values = values
+        };
+}

--- a/tests/HslBikeApp.Tests/Services/OpenDataServiceTests.cs
+++ b/tests/HslBikeApp.Tests/Services/OpenDataServiceTests.cs
@@ -1,0 +1,138 @@
+using System.Net;
+using System.Text;
+using HslBikeApp.Services;
+
+namespace HslBikeApp.Tests.Services;
+
+public class OpenDataServiceTests
+{
+    [Fact]
+    public async Task FetchOpenDataAsync_WhenResponseIsSuccessful_ReturnsDeserialisedTimeSeries()
+    {
+        var responseJson =
+            """
+            [
+              {
+                "sourceId": "uimastadion",
+                "displayName": "Uimastadion",
+                "lat": 60.1857,
+                "lon": 24.9282,
+                "attributionUrl": "https://example.com/uimastadion",
+                "unit": "visitors",
+                "description": "Live visitor count",
+                "timestamps": ["2026-05-18T10:00:00+00:00", "2026-05-18T10:15:00+00:00"],
+                "values": [185, 192]
+              }
+            ]
+            """;
+
+        var httpClient = new HttpClient(new StubHttpMessageHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+        })));
+        var service = new OpenDataService(httpClient, "https://aggregator.example");
+
+        var series = await service.FetchOpenDataAsync();
+
+        var single = Assert.Single(series);
+        Assert.Equal("uimastadion", single.SourceId);
+        Assert.Equal("Uimastadion", single.DisplayName);
+        Assert.Equal(60.1857, single.Lat);
+        Assert.Equal(24.9282, single.Lon);
+        Assert.Equal("https://example.com/uimastadion", single.AttributionUrl);
+        Assert.Equal("visitors", single.Unit);
+        Assert.Equal("Live visitor count", single.Description);
+        Assert.Equal(2, single.Timestamps.Count);
+        Assert.Equal(new[] { 185.0, 192.0 }, single.Values);
+        Assert.True(service.LastFetchSucceeded);
+        Assert.Null(service.LastErrorMessage);
+    }
+
+    [Fact]
+    public async Task FetchOpenDataAsync_WhenUnitAndDescriptionAreOmitted_LeavesThemNull()
+    {
+        var responseJson =
+            """
+            [
+              {
+                "sourceId": "legacy-source",
+                "displayName": "Legacy",
+                "lat": 60.0,
+                "lon": 25.0,
+                "attributionUrl": "https://example.com/legacy",
+                "timestamps": [],
+                "values": []
+              }
+            ]
+            """;
+
+        var httpClient = new HttpClient(new StubHttpMessageHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+        })));
+        var service = new OpenDataService(httpClient, "https://aggregator.example");
+
+        var single = Assert.Single(await service.FetchOpenDataAsync());
+
+        Assert.Null(single.Unit);
+        Assert.Null(single.Description);
+    }
+
+    [Fact]
+    public async Task FetchOpenDataAsync_WhenBaseUrlHasTrailingSlash_UsesOpenDataEndpoint()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        var httpClient = new HttpClient(new StubHttpMessageHandler((request, _) =>
+        {
+            capturedRequest = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[]", Encoding.UTF8, "application/json")
+            });
+        }));
+        var service = new OpenDataService(httpClient, "https://aggregator.example/");
+
+        await service.FetchOpenDataAsync();
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal("https://aggregator.example/api/open-data", capturedRequest.RequestUri?.ToString());
+    }
+
+    [Fact]
+    public async Task FetchOpenDataAsync_WhenHttpRequestFails_ReturnsEmptyListAndRecordsError()
+    {
+        var httpClient = new HttpClient(new StubHttpMessageHandler((_, _) => throw new HttpRequestException("boom")));
+        var service = new OpenDataService(httpClient, "https://aggregator.example");
+
+        var series = await service.FetchOpenDataAsync();
+
+        Assert.Empty(series);
+        Assert.False(service.LastFetchSucceeded);
+        Assert.Equal("Could not load open data from the aggregator backend. GET https://aggregator.example/api/open-data failed.", service.LastErrorMessage);
+    }
+
+    [Fact]
+    public async Task FetchOpenDataAsync_WhenEndpointReturnsNotFound_SetsConfigurationErrorMessage()
+    {
+        var httpClient = new HttpClient(new StubHttpMessageHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound))));
+        var service = new OpenDataService(httpClient, "https://aggregator.example");
+
+        var series = await service.FetchOpenDataAsync();
+
+        Assert.Empty(series);
+        Assert.False(service.LastFetchSucceeded);
+        Assert.Equal("Could not load open data from the aggregator backend. GET https://aggregator.example/api/open-data returned 404 Not Found. Check AggregatorBaseUrl in wwwroot/appsettings.json.", service.LastErrorMessage);
+    }
+
+    [Fact]
+    public void OpenDataService_WhenBaseUrlIsNull_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => new OpenDataService(new HttpClient(), null!));
+    }
+
+    [Fact]
+    public void OpenDataService_WhenHttpClientIsNull_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new OpenDataService(null!, "https://example.com"));
+    }
+}

--- a/tests/HslBikeApp.Tests/Services/ServiceConfigurationTests.cs
+++ b/tests/HslBikeApp.Tests/Services/ServiceConfigurationTests.cs
@@ -58,13 +58,15 @@ public class ServiceConfigurationTests
         var snapshotService = new SnapshotService(httpClient, baseUrl);
         var statisticsService = new StatisticsService(httpClient, baseUrl);
         var liveStationService = new LiveStationService(httpClient, baseUrl);
+        var openDataService = new OpenDataService(httpClient, baseUrl);
 
         await stationService.FetchStationsAsync();
         await snapshotService.FetchSnapshotsAsync();
         await statisticsService.FetchStatisticsAsync("001");
         await liveStationService.RefreshAsync();
+        await openDataService.FetchOpenDataAsync();
 
-        Assert.Equal(4, capturedUris.Count);
+        Assert.Equal(5, capturedUris.Count);
         Assert.All(capturedUris, uri =>
         {
             Assert.Equal("aggregator.example", uri.Host);

--- a/tests/HslBikeApp.Tests/State/AppStateTests.cs
+++ b/tests/HslBikeApp.Tests/State/AppStateTests.cs
@@ -33,7 +33,11 @@ public class AppStateTests
             new HttpClient(liveHandler) { BaseAddress = new Uri("https://test.local/") },
             "https://test.local");
 
-        return new AppState(stationService, statisticsService, cycleLaneService, snapshotService, liveStationService, new StubJsRuntime());
+        var openDataService = new OpenDataService(
+            new HttpClient(new MockHttpHandler()) { BaseAddress = new Uri("https://test.local/") },
+            "https://test.local");
+
+        return new AppState(stationService, statisticsService, cycleLaneService, snapshotService, liveStationService, openDataService, new StubJsRuntime());
     }
 
     [Fact]


### PR DESCRIPTION
Closes #25.

## Summary
- New `OpenDataTimeSeries` model + `OpenDataService` matching the backend contract; `LatestAvailable()` helper centralises the `-1` sentinel skip.
- New `OpenDataDetailPanel` component renders generically: large current value + optional unit, optional description subtitle, auto-scaled sparkline of the full series, attribution link, and a "Currently unavailable" state when the latest sample is `-1`.
- `MapView` + `map-interop.js` add a blue circle-marker layer for each source, separate from the bike-station markers. Clicking a marker selects the source and clears any station selection; clicking a station marker clears any open data selection.
- `AppState` fetches open data on init and refreshes every 10 min on its own timer (gated by tab visibility), separate from the 30 s live-station poll.
- DI: `OpenDataService` registered in `Program.cs` from `AggregatorBaseUrl`.

## Depends on
- [TmiKuoste/HslBikeDataAggregator#73](https://github.com/TmiKuoste/HslBikeDataAggregator/pull/73) — adds `unit` and `description` to the backend `OpenDataTimeSeries`. The panel renders gracefully when these are absent, so this PR can ship first if needed.

## Test plan
- [x] `dotnet build HslBikeApp.slnx`
- [x] `dotnet test HslBikeApp.slnx` — 141 passed
- [x] New: `OpenDataTimeSeriesTests` covers `LatestAvailable()` happy path, sentinel skip, all-sentinel, and empty series.
- [x] New: `OpenDataServiceTests` covers success deserialisation (with and without optional fields), trailing-slash URL handling, HTTP failure, 404 with config hint, and constructor argument validation.
- [x] Updated: `ServiceConfigurationTests` includes `OpenDataService`.
- [x] Updated: `AppStateTests` instantiates the new `OpenDataService` ctor dependency.
- [ ] Manual UI check: marker appears at the configured source location, click opens panel, sparkline scales to the data, `-1` renders as "Currently unavailable" (would need a backend with the dependent change deployed).